### PR TITLE
Cube potential docstring

### DIFF
--- a/macrodensity/density_tools.py
+++ b/macrodensity/density_tools.py
@@ -139,7 +139,22 @@ def macroscopic_average(potential, periodicity, resolution):
 #------------------------------------------------------------------------------
 
 def cube_potential(origin, travelled, cube, Grid, nx, ny, nz):
-    """Populates the sampling cube with the potential required"""
+    """Average potential over a cuboid volume element
+
+    Args:
+        origin (3-tuple) : Origin coordinates as fractions of lattice
+            vectors
+        travelled (3-tuple) : Vector displacing volume element from origin, in
+            units of potential grid samples
+        cube (3-tuple) : Dimensions of sampling volume in grid samples
+            (NX, NY, NZ)
+        Grid (numpy.ndarray) : 3-dimensional (nx, ny, nz) array of potential
+            data
+        nx (int) : number of samples on first axis
+        ny (int) : number of samples on second axis
+        nz (int) : number of samples on third axis
+
+    """
 
     # Recalc the origin as grid point coordinates
     n_origin = np.zeros(shape=(3))

--- a/macrodensity/density_tools.py
+++ b/macrodensity/density_tools.py
@@ -154,6 +154,10 @@ def cube_potential(origin, travelled, cube, Grid, nx, ny, nz):
         ny (int) : number of samples on second axis
         nz (int) : number of samples on third axis
 
+    Returns:
+        2-tuple:
+            (mean, variance) of potential samples in volume
+
     """
 
     # Recalc the origin as grid point coordinates


### PR DESCRIPTION
A student asked about this function *density_tools.cube_potential* today so I worked through it and assembled a docstring. I do have a few other questions about this function though:

- Why are the nx, ny, nz arguments needed? Does it save a lot of time to pass them rather than check *Grid.shape*?
- As part of the style clean-up, can we move to lower-case for "Grid"? Conventionally capitals mean classes, and this threw me initially.
- The function is called "cube_potential" but there is nothing enforcing the volume region to be a cube; in fact in many cases it would be impossible for it to be a true cube in real-space as the grid spacing is different in each direction. The name also does not make it clear that it returns an average.
- As far as I can tell "cuboid_average" follows a vector and so might not be a cuboid. (Take a large cube and send it off diagonally and you end up sampling a volume that has ten faces?) Also, it returns an array of averages rather than a single value. Maybe these functions should be named cuboid_average and cuboid_sweep?
