### PR TITLE
Add inverse participation ratio functionality

### DIFF
--- a/macrodensity/density_tools.py
+++ b/macrodensity/density_tools.py
@@ -476,3 +476,16 @@ def GCD_List(list):
     """
     return reduce(GCD, list)
 #------------------------------------------------------------------------------
+def inverse_participation_ratio(density):
+    """ Calculate the IPR, which is Psi**4 or Rho**2
+    Input: density, a 1-D flattened grid of the electron density for the state
+           this is calculated from the PARCHG in VASP
+    Output: ipr, float
+    """
+
+    sq = sum(i**2 for i in density)
+    fr = sum(i**4 for i in density)
+    ifr = 1 / (len(density) * fr)
+    isq = 1 / (len(density) * sq)
+    return fr / sq**2
+

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -114,6 +114,16 @@ class TestAveragingFunctions(unittest.TestCase):
         self.assertAlmostEqual(potential, 1.0)
         self.assertAlmostEqual(variance, 3.6296296296296298)
 
+    def test_ipr(self):
+        '''Test the ipr function'''
+
+        parchg = pkg_resources.resource_filename(
+                    __name__, path_join('..', 'CHGCAR.test'))
+
+        dens, ngx, ngy, ngz, lattice = md.read_vasp_density(parchg, 
+                                                           quiet=True)
+        self.assertAlmostEqual(md.inverse_participation_ratio(dens),
+                1.407e-5)
 
 class TestGeometryFunctions(unittest.TestCase):
     '''Test the functions that do geometry and trig'''
@@ -184,6 +194,4 @@ class TestGeometryFunctions(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    contents = os.listdir("/home/travis/build/WMD-group/MacroDensity/tests/")
-    print("CONTENTS: ", contents)
     unittest.main()


### PR DESCRIPTION
The inverse participation ratio (IPR) allows one to characterise the localisation of a density. It is calculated as: [sum (1/des_i **4)]/[sum (1/dens_i**2)**2] - where the sum runs over all grid points.
For a fully localised state ipr = 1. 

There is a unit test included with this PR.